### PR TITLE
Add "legacy" subpackage

### DIFF
--- a/legacy/activity.go
+++ b/legacy/activity.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+import (
+	"encoding/json"
+)
+
+// Activity represents a report activity
+type Activity struct {
+	ID                *uint64         `json:"id"`
+	Editable          *bool           `json:"editable"`
+	IsInternal        *bool           `json:"is_internal"`
+	Message           *string         `json:"message"`
+	MarkdownMessage   *string         `json:"markdown_message"`
+	AutomatedResponse *bool           `json:"automated_response"`
+	CreatedAt         *Timestamp      `json:"created_at"`
+	UpdatedAt         *Timestamp      `json:"updated_at"`
+	RawActor          json.RawMessage `json:"actor"`
+	AssignedUser      *User           `json:"assigned_user"`
+	GeniusExecutionID *string         `json:"genius_execution_id"` // TODO: This may be wrong type
+	FileName          *string         `json:"file_name"`
+	ExpiringURL       *string         `json:"expiring_url"`
+	Type              *string         `json:"type"`
+}

--- a/legacy/attachment.go
+++ b/legacy/attachment.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// Attachment represents a report attachment
+type Attachment struct {
+	ID          *uint64 `json:"id"`
+	FileName    *string `json:"file_name"`
+	ExpiringURL *string `json:"expiring_url"`
+	Type        *string `json:"type"`
+}

--- a/legacy/badge.go
+++ b/legacy/badge.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// Badge represents a badge object
+type Badge struct {
+	Name     *string `json:"name"`
+	ImageURL *string `json:"image_url"`
+}

--- a/legacy/group.go
+++ b/legacy/group.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// Group represents a group
+type Group struct {
+	ID               *uint64  `json:"id"`
+	Name             *string  `json:"name"`
+	TeamMembersCount *uint64  `json:"team_members_count"`
+	Permissions      []string `json:"permissions"`
+	Immutable        *bool    `json:"immutable"`
+	TeamMemberIDs    []User   `json:"team_member_ids"`
+}

--- a/legacy/legacy.go
+++ b/legacy/legacy.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// Imports
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	libraryVersion = "1"
+	defaultBaseURL = "https://hackerone.com/"
+	userAgent      = "uber/h1/v" + libraryVersion
+)
+
+// A Client manages communication with the H1.
+type Client struct {
+	client *http.Client // HTTP client used to communicate.
+
+	// Base URL for requests. Defaults to the public H1. BaseURL should always be specified with a trailing slash.
+	BaseURL *url.URL
+
+	// User agent used when communicating with H1.
+	UserAgent string
+
+	common service // Reuse a single struct instead of allocating one for each service on the heap.
+
+	// Services used for talking to different parts of H1.
+	Session *SessionService
+	User    *UserService
+	Team    *TeamService
+	Report  *ReportService
+}
+
+type service struct {
+	client *Client
+}
+
+// NewClient returns a new client. If a nil httpClient is provided, http.DefaultClient will be used.
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	baseURL, _ := url.Parse(defaultBaseURL)
+
+	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
+	c.common.client = c
+	c.Session = (*SessionService)(&c.common)
+	c.User = (*UserService)(&c.common)
+	c.Team = (*TeamService)(&c.common)
+	c.Report = (*ReportService)(&c.common)
+
+	return c
+}
+
+// NewRequest creates an request. A relative URL can be provided in urlStr
+func (c *Client) NewRequest(method, urlStr string, body io.Reader) (*http.Request, error) {
+	rel, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, c.BaseURL.ResolveReference(rel).String(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("User-Agent", c.UserAgent)
+
+	return req, nil
+}
+
+// Response is a H1 response.  This wraps the standard http.Response and provides convenience fields for pagination
+type Response struct {
+	*http.Response
+}
+
+// ErrorResponse wraps a http.Response and is returned when the API returns an error.
+type ErrorResponse struct {
+	Response *http.Response // HTTP response that caused this error
+}
+
+// ErrorResponse needs to implement Error to be a valid error type.
+func (r *ErrorResponse) Error() string {
+	return fmt.Sprintf("%v %v: %d", r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode)
+}
+
+// CheckResponse determines if the given http.Response was an error and converts it to a h1.ErrorResponse if so
+func CheckResponse(r *http.Response) error {
+	if c := r.StatusCode; 200 <= c && c <= 299 {
+		return nil
+	}
+	errorResponse := &ErrorResponse{Response: r}
+	return errorResponse
+}
+
+// Do sends an request and returns the response.
+func (c *Client) Do(req *http.Request, resource interface{}) (*Response, error) {
+	// Actually do the request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Make a response object
+	response := &Response{Response: resp}
+
+	// If request returned an error, return the response and err back to user to inspect
+	if err := CheckResponse(resp); err != nil {
+		return response, err
+	}
+
+	// Decode if a resource was provided
+	if resource != nil {
+		if err := json.NewDecoder(resp.Body).Decode(resource); err != nil {
+			return response, err
+		}
+	}
+
+	// Return success
+	return response, nil
+}

--- a/legacy/legacy_test.go
+++ b/legacy/legacy_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// Imports
+import (
+	"github.com/stretchr/testify/assert"
+
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func Test_ErrorResponse(t *testing.T) {
+	// Check that .Error results in a correct string
+	u, err := url.Parse("https://hackerone.com/admin")
+	assert.Nil(t, err)
+	errResp := ErrorResponse{
+		Response: &http.Response{
+			StatusCode: 1337,
+			Request: &http.Request{
+				Method: "POST",
+				URL:    u,
+			},
+		},
+	}
+	assert.Equal(t, "POST https://hackerone.com/admin: 1337", errResp.Error())
+}
+
+func Test_NewClient(t *testing.T) {
+	// Check that it uses the DefaultClient
+	c := NewClient(nil)
+	assert.Equal(t, c.client, http.DefaultClient)
+}
+
+func Test_CheckResponse(t *testing.T) {
+	// Check that a 200 returns nil
+	resp := &http.Response{
+		StatusCode: 200,
+	}
+	err := CheckResponse(resp)
+	assert.Nil(t, err)
+
+	// Check that an error response unmarshals correctly
+	resp = &http.Response{
+		StatusCode: 400,
+		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte{})),
+	}
+	err = CheckResponse(resp)
+	assert.NotNil(t, err)
+	expected := &ErrorResponse{
+		Response: resp,
+	}
+	assert.Equal(t, expected, err)
+}
+
+func Test_NewRequest(t *testing.T) {
+	// Check that an invalid URL fails
+	client := NewClient(nil)
+	_, err := client.NewRequest("GET", "http://[fe80::1%en0]/", nil)
+	assert.NotNil(t, err)
+
+	// Check that an invalid base URL fails
+	badclient := NewClient(nil)
+	badclient.BaseURL = &url.URL{
+		Scheme: "http://[fe80::1%en0]/",
+	}
+	_, err = badclient.NewRequest("GET", "/", nil)
+	assert.NotNil(t, err)
+
+	// Check that a relative path resolves correctly
+	req, err := client.NewRequest("GET", "/relativepath", nil)
+	assert.Nil(t, err)
+	u, err := url.Parse("https://hackerone.com/relativepath")
+	assert.Nil(t, err)
+	expected := &http.Request{
+		Method:     "GET",
+		URL:        u,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"User-Agent": []string{userAgent},
+		},
+		Host: "hackerone.com",
+	}
+	assert.Equal(t, expected, req)
+}
+
+func Test_Client_Do(t *testing.T) {
+	// Verify that an invalid request fails
+	client := NewClient(nil)
+	_, err := client.Do(&http.Request{}, nil)
+	assert.NotNil(t, err)
+
+	// Verify that a error response results in an error
+	errorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Oh No", 500)
+	}))
+	defer errorServer.Close()
+	u, err := url.Parse(errorServer.URL)
+	assert.Nil(t, err)
+	_, err = client.Do(&http.Request{
+		URL: u,
+	}, nil)
+	assert.NotNil(t, err)
+
+	// Verify that a invalid response results in an error
+	invalidServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "Invalid JSON")
+	}))
+	defer invalidServer.Close()
+	u, err = url.Parse(invalidServer.URL)
+	assert.Nil(t, err)
+	var result json.RawMessage
+	_, err = client.Do(&http.Request{
+		URL: u,
+	}, &result)
+	assert.NotNil(t, err)
+
+	// Verify that a success response results in a struct
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "\"Hello World\"")
+	}))
+	defer successServer.Close()
+	u, err = url.Parse(successServer.URL)
+	assert.Nil(t, err)
+	var successResult json.RawMessage
+	_, err = client.Do(&http.Request{
+		URL: u,
+	}, &successResult)
+	assert.Nil(t, err)
+	assert.Equal(t, json.RawMessage("\"Hello World\""), successResult)
+}

--- a/legacy/report-summary.go
+++ b/legacy/report-summary.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// ReportSummary represents a report summary
+type ReportSummary struct {
+	Category    *string `json:"category"`
+	CanView     *bool   `json:"can_view?"`
+	CanCreate   *bool   `json:"can_create?"`
+	Content     *string `json:"content"`
+	ContentHTML *string `json:"content_html"`
+}

--- a/legacy/report.go
+++ b/legacy/report.go
@@ -22,7 +22,7 @@ package legacy
 
 import (
 	"bytes"
-	"encoding/json"
+//	"encoding/json"
 	"fmt"
 	"net/url"
 )
@@ -147,7 +147,7 @@ func (s *ReportService) Create(handle string, report *Report) (*Response, error)
 }
 
 // AddSummary assigns a group by ID to a report
-func (s *ReportService) AddSummary(id uint64, summary *ReportSummary) (*Response, error) {
+/*func (s *ReportService) AddSummary(id uint64, summary *ReportSummary) (*Response, error) {
 	user, resp, err := s.client.Session.GetCurrentUser()
 	if err != nil {
 		return resp, err
@@ -180,7 +180,7 @@ func (s *ReportService) AddSummary(id uint64, summary *ReportSummary) (*Response
 	}
 
 	return resp, err
-}
+}*/
 
 // ReportBulkResponse is used as a response for multiple report methods
 type ReportBulkResponse struct {
@@ -260,13 +260,13 @@ func (s *ReportService) Close(id uint64, message string, state string, opts *Rep
 }
 
 // Reopen reopens a report
-func (s *ReportService) Reopen(id uint64, message string) (*ReportBulkResponse, *Response, error) {
+/*func (s *ReportService) Reopen(id uint64, message string) (*ReportBulkResponse, *Response, error) {
 	body := url.Values{
 		"message": []string{message},
 	}
 
 	return s.bulk(id, "reopen", body)
-}
+}*/
 
 // Comment comments on a report
 func (s *ReportService) Comment(id uint64, message string, internal bool) (*ReportBulkResponse, *Response, error) {
@@ -283,7 +283,7 @@ func (s *ReportService) Comment(id uint64, message string, internal bool) (*Repo
 }
 
 // AssignUser assigns a user by ID to a report
-func (s *ReportService) AssignUser(id uint64, message string, assignee uint64) (*ReportBulkResponse, *Response, error) {
+/*func (s *ReportService) AssignUser(id uint64, message string, assignee uint64) (*ReportBulkResponse, *Response, error) {
 	body := url.Values{
 		"message":     []string{message},
 		"substate":    []string{"user"},
@@ -302,4 +302,4 @@ func (s *ReportService) AssignGroup(id uint64, message string, assignee uint64) 
 	}
 
 	return s.bulk(id, "assign-to", body)
-}
+}*/

--- a/legacy/report.go
+++ b/legacy/report.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// ReportAbilities dictates what can be done with a report
+type ReportAbilities struct {
+	CanManage                   *bool   `json:"can_manage?"`
+	CanExport                   *bool   `json:"can_export?"`
+	CanAddComment               *bool   `json:"can_add_comment?"`
+	CanChangeState              *bool   `json:"can_change_state?"`
+	CanReopen                   *bool   `json:"can_reopen?"`
+	CanAwardBounty              *bool   `json:"can_award_bounty?"`
+	CanAwardSwag                *bool   `json:"can_award_swag?"`
+	CanSuggestBountyAmount      *bool   `json:"can_suggest_bounty_amount?"`
+	CanAssignToUser             *bool   `json:"can_assign_to_user?"`
+	CanHideTimeline             *bool   `json:"can_hide_timeline?"`
+	CanAgreeOnGoingPublic       *bool   `json:"can_agree_on_going_public?"`
+	CanBePubliclyDisclosed      *bool   `json:"can_be_publicly_disclosed?"`
+	CanPostInternalComments     *bool   `json:"can_post_internal_comments?"`
+	CanManageCommonResponses    *bool   `json:"can_manage_common_responses?"`
+	CanChangeTitle              *bool   `json:"can_change_title?"`
+	CanChangeVulnerabilityTypes *bool   `json:"can_change_vulnerability_types?"`
+	CanBeManuallyDisclosed      *bool   `json:"can_be_manually_disclosed?"`
+	CanClone                    *bool   `json:"can_clone?"`
+	CanClose                    *bool   `json:"can_close?"`
+	CanBanResearcher            *bool   `json:"can_ban_researcher?"`
+	AssignableTeamMembers       []User  `json:"assignable_team_members"`
+	AssignableTeamMemberGroups  []Group `json:"assignable_team_member_groups"`
+}
+
+// Report represents a report
+type Report struct {
+	ID                               *uint64                   `json:"id"`
+	URL                              *string                   `json:"url"`
+	Title                            *string                   `json:"title"`
+	State                            *string                   `json:"state"`
+	Substate                         *string                   `json:"substate"`
+	ReadableSubstate                 *string                   `json:"readable_substate"`
+	CreatedAt                        *Timestamp                `json:"created_at"`
+	Assignee                         *User                     `json:"assignee"` // TODO: this is probably wrong
+	CreateReferenceURL               *string                   `json:"create_reference_url"`
+	Reporter                         *User                     `json:"reporter"` // TODO: There are special objects like team_context here
+	PromoteBounties                  *bool                     `json:"promote_bounties"`
+	Team                             *Team                     `json:"team"`
+	HasBounty                        *bool                     `json:"has_bounty?"`
+	CanViewTeam                      *bool                     `json:"can_view_team"`
+	IsExternalBug                    *bool                     `json:"is_external_bug"`
+	IsParticipant                    *bool                     `json:"is_participant"`
+	Stage                            *uint                     `json:"stage"` // TODO: No idea what this is and the type
+	Public                           *bool                     `json:"public"`
+	CVEIDs                           []string                  `json:"cve_ids"` // TODO: Is this the correct type?
+	DisclosedAt                      *Timestamp                `json:"disclosed_at"`
+	BugReporterAgreedOnGoingPublicAt *Timestamp                `json:"bug_reporter_agreed_on_going_public_at"`
+	TeamMemberAgreedOnGoingPublicAt  *Timestamp                `json:"team_member_agreed_on_going_public_at"`
+	MediationRequested               *bool                     `json:"mediation_requested"`
+	Subscribed                       *bool                     `json:"subscribed"`
+	SuggestedBounty                  *uint64                   `json:"suggested_bounty"`
+	VulnerabilityInformation         *string                   `json:"vulnerability_information"`
+	VulnerabilityInformationHTML     *string                   `json:"vulnerability_information_html"`
+	Triggers                         map[string]CommonResponse `json:"triggers"`
+	VulnerabilityTypes               []VulnerabilityType       `json:"vulnerability_types"`
+	Attachments                      []Attachment              `json:"attachments"`
+	Abilities                        ReportAbilities           `json:"abilities"`
+	IsMemberOfTeam                   *bool                     `json:"is_member_of_team"`
+	Activities                       []Activity                `json:"activities"`
+	Summaries                        []ReportSummary           `json:"summaries"`
+}
+
+// ReportService handles communication with the bug related methods of H1.
+type ReportService service
+
+// Get retrieves a report by ID
+func (s *ReportService) Get(id uint64) (*Report, *Response, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("reports/%d.json", id), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	report := new(Report)
+	resp, err := s.client.Do(req, report)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return report, resp, err
+}
+
+// Create creates a new report and returns the ID
+func (s *ReportService) Create(handle string, report *Report) (*Response, error) {
+	user, resp, err := s.client.Session.GetCurrentUser()
+	if err != nil {
+		return resp, err
+	}
+
+	body := url.Values{
+		"report[title]":                     []string{*report.Title},
+		"report[vulnerability_information]": []string{*report.VulnerabilityInformation},
+		"report[vulnerability_type_ids][]":  []string{"126768"}, // TODO: Don't hardcode this to None
+	}
+
+	req, err := s.client.NewRequest("POST", fmt.Sprintf("%s/reports", handle), bytes.NewBufferString(body.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+	req.Header.Add("X-CSRF-Token", *user.CSRFToken)
+
+	reportInfo := struct {
+		Redirect *string `json:"redirect"`
+		ReportID *uint64 `json:"report_id"`
+	}{}
+	resp, err = s.client.Do(req, &reportInfo)
+	if err != nil {
+		return resp, err
+	}
+	report.ID = reportInfo.ReportID
+
+	return resp, err
+}
+
+// AddSummary assigns a group by ID to a report
+func (s *ReportService) AddSummary(id uint64, summary *ReportSummary) (*Response, error) {
+	user, resp, err := s.client.Session.GetCurrentUser()
+	if err != nil {
+		return resp, err
+	}
+
+	body := struct {
+		*ReportSummary
+		ActionType string `json:"action_type"`
+	}{
+		ReportSummary: summary,
+		ActionType:    "publish",
+	}
+
+	buf := bytes.NewBuffer(nil)
+	dec := json.NewEncoder(buf)
+	if dec.Encode(&body) != nil {
+		return nil, err
+	}
+	req, err := s.client.NewRequest("POST", fmt.Sprintf("reports/%d/summaries", id), buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+	req.Header.Add("X-CSRF-Token", *user.CSRFToken)
+
+	resp, err = s.client.Do(req, summary)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+// ReportBulkResponse is used as a response for multiple report methods
+type ReportBulkResponse struct {
+	Flash   *string  `json:"flash"`
+	Reports []Report `json:"reports"`
+}
+
+// bulk uses the /reports/bulk endpoint a report
+func (s *ReportService) bulk(id uint64, replyAction string, body url.Values) (*ReportBulkResponse, *Response, error) {
+	user, resp, err := s.client.Session.GetCurrentUser()
+	if err != nil {
+		return nil, resp, err
+	}
+
+	body.Add("reply_action", replyAction)
+	body.Add("reports_count", "1")
+	body.Add("report_ids[]", fmt.Sprintf("%d", id))
+
+	req, err := s.client.NewRequest("POST", "/reports/bulk", bytes.NewBufferString(body.Encode()))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+	req.Header.Add("X-CSRF-Token", *user.CSRFToken)
+
+	var reportBulkResponse ReportBulkResponse
+	resp, err = s.client.Do(req, &reportBulkResponse)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &reportBulkResponse, resp, err
+}
+
+// ReportChangeStateOptions provides optional arguments to ReportService's ChangeState method
+type ReportChangeStateOptions struct {
+	Reference *string
+}
+
+// ChangeState changes a report state
+func (s *ReportService) ChangeState(id uint64, message string, state string, opts *ReportChangeStateOptions) (*ReportBulkResponse, *Response, error) {
+	body := url.Values{
+		"message":  []string{message},
+		"substate": []string{state},
+	}
+
+	if opts != nil {
+		if opts.Reference != nil {
+			body.Add("reference", *opts.Reference)
+		}
+	}
+
+	return s.bulk(id, "change-state", body)
+}
+
+// ReportCloseOptions provides optional arguments to ReportService's Close method
+type ReportCloseOptions struct {
+	AddReporterToOriginal *bool
+	OriginalReportID      *uint64
+}
+
+// Close closes a report
+func (s *ReportService) Close(id uint64, message string, state string, opts *ReportCloseOptions) (*ReportBulkResponse, *Response, error) {
+	body := url.Values{
+		"message":  []string{message},
+		"substate": []string{state},
+	}
+
+	if opts != nil {
+		if opts.OriginalReportID != nil {
+			body.Add("original_report_id", fmt.Sprintf("%d", *opts.OriginalReportID))
+		}
+	}
+
+	return s.bulk(id, "close-report", body)
+}
+
+// Reopen reopens a report
+func (s *ReportService) Reopen(id uint64, message string) (*ReportBulkResponse, *Response, error) {
+	body := url.Values{
+		"message": []string{message},
+	}
+
+	return s.bulk(id, "reopen", body)
+}
+
+// Comment comments on a report
+func (s *ReportService) Comment(id uint64, message string, internal bool) (*ReportBulkResponse, *Response, error) {
+	body := url.Values{
+		"message": []string{message},
+	}
+	if internal {
+		body.Add("is_internal", "true")
+	} else {
+		body.Add("is_internal", "false")
+	}
+
+	return s.bulk(id, "add-comment", body)
+}
+
+// AssignUser assigns a user by ID to a report
+func (s *ReportService) AssignUser(id uint64, message string, assignee uint64) (*ReportBulkResponse, *Response, error) {
+	body := url.Values{
+		"message":     []string{message},
+		"substate":    []string{"user"},
+		"assignee_id": []string{fmt.Sprintf("%d", assignee)},
+	}
+
+	return s.bulk(id, "assign-to", body)
+}
+
+// AssignGroup assigns a group by ID to a report
+func (s *ReportService) AssignGroup(id uint64, message string, assignee uint64) (*ReportBulkResponse, *Response, error) {
+	body := url.Values{
+		"message":     []string{message},
+		"substate":    []string{"group"},
+		"assignee_id": []string{fmt.Sprintf("%d", assignee)},
+	}
+
+	return s.bulk(id, "assign-to", body)
+}

--- a/legacy/resource.go
+++ b/legacy/resource.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// ProfilePictureURLs represents the profile pic
+type ProfilePictureURLs struct {
+	Small  *string `json:"small"`
+	Medium *string `json:"medium"`
+	Large  *string `json:"large"`
+}
+
+// Bool allocates a new bool value to store v at and returns a pointer to it.
+func Bool(v bool) *bool { return &v }
+
+// String allocates a new bool value to store v at and returns a pointer to it.
+func String(v string) *string { return &v }
+
+// Int allocates a new bool value to store v at and returns a pointer to it.
+func Int(v int) *int { return &v }

--- a/legacy/session.go
+++ b/legacy/session.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+)
+
+// SessionService handles communication with the session related methods of H1.
+type SessionService service
+
+// SessionUser describes the current user for a session
+type SessionUser struct {
+	CSRFToken *string `json:"csrf_token"`
+	SignedIn  *bool   `json:"signed_in?"`
+}
+
+// GetCurrentUser returns information about the logged in user for the session (including the current CSRF token)
+func (s *SessionService) GetCurrentUser() (*SessionUser, *Response, error) {
+	req, err := s.client.NewRequest("GET", "current_user", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	var user SessionUser
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, resp, err
+	}
+
+	return &user, resp, nil
+}
+
+// GetTeams returns the current user's teams
+func (s *SessionService) GetTeams() ([]Team, *Response, error) {
+	req, err := s.client.NewRequest("GET", "teams", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	var teams []Team
+	resp, err := s.client.Do(req, &teams)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teams, resp, err
+}
+
+// Acquire attempts to authenticate with the provided credentials
+func (s *SessionService) Acquire(email string, password string) (*Response, error) {
+	user, resp, err := s.GetCurrentUser()
+	if err != nil {
+		return resp, err
+	}
+
+	body := url.Values{
+		"authenticity_token": []string{*user.CSRFToken},
+		"user[email]":        []string{email},
+		"user[password]":     []string{password},
+	}
+
+	req, err := s.client.NewRequest("POST", "users/sign_in", bytes.NewBufferString(body.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "text/html")
+
+	resp, err = s.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/legacy/session.go
+++ b/legacy/session.go
@@ -58,7 +58,7 @@ func (s *SessionService) GetCurrentUser() (*SessionUser, *Response, error) {
 }
 
 // GetTeams returns the current user's teams
-func (s *SessionService) GetTeams() ([]Team, *Response, error) {
+/*func (s *SessionService) GetTeams() ([]Team, *Response, error) {
 	req, err := s.client.NewRequest("GET", "teams", nil)
 	if err != nil {
 		return nil, nil, err
@@ -73,7 +73,7 @@ func (s *SessionService) GetTeams() ([]Team, *Response, error) {
 	}
 
 	return teams, resp, err
-}
+}*/
 
 // Acquire attempts to authenticate with the provided credentials
 func (s *SessionService) Acquire(email string, password string) (*Response, error) {

--- a/legacy/session_test.go
+++ b/legacy/session_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// Imports
+import (
+	"github.com/stretchr/testify/assert"
+
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func Test_Session_GetCurrentUser(t *testing.T) {
+	errorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "tests/current_user.json")
+	}))
+	defer errorServer.Close()
+	u, err := url.Parse(errorServer.URL)
+	assert.Nil(t, err)
+
+	client := NewClient(nil)
+	client.BaseURL = u
+	assert.Nil(t, err)
+
+	user, _, err := client.Session.GetCurrentUser()
+	assert.Nil(t, err)
+	assert.Equal(t, &SessionUser{
+		CSRFToken: String("jJz31wvEtnbmhsoa+Iv4eDJknSHbccnAr0Qss10rp5QJQIwh+lPuDa3WPMV0DgHiIvwDpRCxX5XKkoQ+bw4vOw=="),
+		SignedIn:  Bool(false),
+	}, user)
+}

--- a/legacy/team.go
+++ b/legacy/team.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+import (
+	"fmt"
+)
+
+// TeamService handles communication with the report related methods of the H1 API.
+type TeamService service
+
+// TeamProfile represents a H1 team
+type TeamProfile struct {
+	Name          *string `json:"name"`
+	TwitterHandle *string `json:"twitter_handle"`
+	Website       *string `json:"website"`
+	About         string  `json:"about"`
+}
+
+// Team represents a H1 team
+type Team struct {
+	ID                                uint64             `json:"id"`
+	Handle                            *string            `json:"handle"`
+	URL                               *string            `json:"url"`
+	Profile                           TeamProfile        `json:"profile"`
+	Policy                            *string            `json:"policy"`
+	Scopes                            []string           `json:"scopes"`
+	CoverColor                        *string            `json:"cover_color"`
+	TwitterHandle                     *string            `json:"twitter_handle"`
+	IBB                               *bool              `json:"ibb"`
+	HasCoverPhoto                     *bool              `json:"has_cover_photo"`
+	ProfilePictureURLs                ProfilePictureURLs `json:"profile_picture_urls"`
+	ExternalURL                       *string            `json:"external_url"`
+	RejectingSubmissions              *bool              `json:"rejecting_submissions"`
+	OffersSwag                        *bool              `json:"offers_swag"`
+	OffersBounties                    *bool              `json:"offers_bounties"`
+	BountiesPaid                      *float64           `json:"bounties_paid"`
+	ResearcherCount                   *uint64            `json:"researcher_count"`
+	BugCount                          *uint64            `json:"bug_count"`
+	BaseBounty                        *uint64            `json:"base_bounty"`
+	ShowTotalBountiesPaid             *bool              `json:"show_total_bounties_paid"`
+	ShowAverageBounty                 *bool              `json:"show_average_bounty"`
+	ShowTopBounties                   *bool              `json:"show_top_bounties"`
+	ShowMeanBountyTime                *bool              `json:"show_mean_bounty_time"`
+	ShowMeanFirstResponseTime         *bool              `json:"show_mean_first_response_time"`
+	ShowMeanResolutionTime            *bool              `json:"show_mean_resolution_time"`
+	TargetSignal                      *int64             `json:"target_signal"`
+	CurrentUserReachedAbuseLimit      *bool              `json:"current_user_reached_abuse_limit"`
+	CurrentUserReachedTeamSignalLimit *bool              `json:"current_user_reached_team_signal_limit"`
+	TeamsUploadCoverPhotoEnabled      *bool              `json:"teams_upload_cover_photo_enabled"`
+	CanViewThanks                     *bool              `json:"can_view_thanks"`
+	CanViewPolicyVersions             *bool              `json:"can_view_policy_versions"`
+	LastPolicyChangeAt                *Timestamp         `json:"last_policy_change_at"`
+	CanManageTeamMemberGroups         *bool              `json:"can_manage_team_member_groups"`
+	CanInviteTeamMember               *bool              `json:"can_invite_team_member"`
+	HackbotGeniusEnabled              *bool              `json:"hackbot_genius_enabled"`
+	Permissions                       []string           `json:"permissions"`
+}
+
+// GetByHandle a team by handle
+func (s *TeamService) Get(handle string) (*Team, *Response, error) {
+	req, err := s.client.NewRequest("GET", handle, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	team := new(Team)
+	resp, err := s.client.Do(req, team)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return team, resp, err
+}
+
+// TeamProfileMetrics represents a H1 team's profile metrics
+type TeamProfileMetrics struct {
+	MeanTimeToFirstResponse *float64 `json:"mean_time_to_first_response"`
+	MeanTimeToResolution    *float64 `json:"mean_time_to_resolution"`
+	MeanTimeToBounty        *float64 `json:"mean_time_to_bounty"`
+	TotalBountiesPaidPrefix *string  `json:"total_bounties_paid_prefix"` // TODO: Is this the correct type?
+	TotalBountiesPaid       *float64 `json:"total_bounties_paid"`
+	AverageBountyLowerRange *float64 `json:"average_bounty_lower_range"`
+	AverageBountyUpperRange *float64 `json:"average_bounty_upper_range"`
+	TopBountyLowerRange     *float64 `json:"top_bounty_lower_range"`
+	TopBountyUpperRange     *float64 `json:"top_bounty_upper_range"`
+}
+
+// GetProfileMetrics returns the profile metrics of a team by handle
+func (s *TeamService) GetProfileMetrics(handle string) (*TeamProfileMetrics, *Response, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/reporters", handle), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	profileMetrics := new(TeamProfileMetrics)
+	resp, err := s.client.Do(req, profileMetrics)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return profileMetrics, resp, err
+}
+
+// ListReporters returns the reporters to a team by handle
+func (s *TeamService) ListReporters(handle string) ([]User, *Response, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/reporters", handle), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	var users []User
+	resp, err := s.client.Do(req, &users)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return users, resp, err
+}
+
+// CommonResponse represents a common ersponse object
+type CommonResponse struct {
+	ID      *uint64 `json:"id"`
+	Title   *string `json:"title"`
+	Message *string `json:"message"`
+}
+
+// ListCommonResponses returns the common responses for a team by handle
+func (s *TeamService) ListCommonResponses(handle string) ([]CommonResponse, *Response, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/common_responses.json", handle), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	var commonResponses []CommonResponse
+	resp, err := s.client.Do(req, &commonResponses)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return commonResponses, resp, err
+}

--- a/legacy/team.go
+++ b/legacy/team.go
@@ -21,7 +21,7 @@
 package legacy
 
 import (
-	"fmt"
+//	"fmt"
 )
 
 // TeamService handles communication with the report related methods of the H1 API.
@@ -76,7 +76,7 @@ type Team struct {
 }
 
 // GetByHandle a team by handle
-func (s *TeamService) Get(handle string) (*Team, *Response, error) {
+/*func (s *TeamService) Get(handle string) (*Team, *Response, error) {
 	req, err := s.client.NewRequest("GET", handle, nil)
 	if err != nil {
 		return nil, nil, err
@@ -91,7 +91,7 @@ func (s *TeamService) Get(handle string) (*Team, *Response, error) {
 	}
 
 	return team, resp, err
-}
+}*/
 
 // TeamProfileMetrics represents a H1 team's profile metrics
 type TeamProfileMetrics struct {
@@ -107,7 +107,7 @@ type TeamProfileMetrics struct {
 }
 
 // GetProfileMetrics returns the profile metrics of a team by handle
-func (s *TeamService) GetProfileMetrics(handle string) (*TeamProfileMetrics, *Response, error) {
+/*func (s *TeamService) GetProfileMetrics(handle string) (*TeamProfileMetrics, *Response, error) {
 	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/reporters", handle), nil)
 	if err != nil {
 		return nil, nil, err
@@ -140,7 +140,7 @@ func (s *TeamService) ListReporters(handle string) ([]User, *Response, error) {
 	}
 
 	return users, resp, err
-}
+}*/
 
 // CommonResponse represents a common ersponse object
 type CommonResponse struct {
@@ -149,7 +149,7 @@ type CommonResponse struct {
 	Message *string `json:"message"`
 }
 
-// ListCommonResponses returns the common responses for a team by handle
+/*// ListCommonResponses returns the common responses for a team by handle
 func (s *TeamService) ListCommonResponses(handle string) ([]CommonResponse, *Response, error) {
 	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/common_responses.json", handle), nil)
 	if err != nil {
@@ -165,4 +165,4 @@ func (s *TeamService) ListCommonResponses(handle string) ([]CommonResponse, *Res
 	}
 
 	return commonResponses, resp, err
-}
+}*/

--- a/legacy/tests/current_user.json
+++ b/legacy/tests/current_user.json
@@ -1,0 +1,1 @@
+{"csrf_token":"jJz31wvEtnbmhsoa+Iv4eDJknSHbccnAr0Qss10rp5QJQIwh+lPuDa3WPMV0DgHiIvwDpRCxX5XKkoQ+bw4vOw==","signed_in?":false,"disclosure_directory_submissions_enabled":false,"new_feature_article_available":false,"show_team_context_in_reports_page":false,"programs_with_api":[],"is_member_of_teams":false}

--- a/legacy/timestamp.go
+++ b/legacy/timestamp.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+import (
+	"time"
+)
+
+// Timestamp represents a time generated from a JSON string
+type Timestamp struct {
+	time.Time
+}
+
+// NewTimestamp creates a new Timestamp object from a ISO8601 date string
+func NewTimestamp(date string) *Timestamp {
+	ts, err := time.Parse(time.RFC3339, date)
+	if err != nil {
+		panic(err)
+	}
+	return &Timestamp{
+		Time: ts,
+	}
+}
+
+// String calls time.Time's String method
+func (t Timestamp) String() string {
+	return t.Time.String()
+}
+
+// UnmarshalJSON helps unmarshal ISO8601 dates in JSON
+func (t *Timestamp) UnmarshalJSON(data []byte) error {
+	var err error
+	(*t).Time, err = time.Parse(`"`+time.RFC3339+`"`, string(data))
+	return err
+}

--- a/legacy/timestamp_test.go
+++ b/legacy/timestamp_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+	"time"
+)
+
+func Test_Timestamp(t *testing.T) {
+	func() {
+		defer func() {
+			if recover() == nil {
+				assert.Fail(t, "NewTimestamp should panic")
+			}
+		}()
+		NewTimestamp("invalid")
+	}()
+	ts := NewTimestamp("2016-02-02T04:05:06.000Z")
+	assert.True(t, ts.Time.Equal(time.Date(2016, 2, 2, 4, 5, 6, 0, time.UTC)))
+	assert.Equal(t, ts.String(), "2016-02-02 04:05:06 +0000 UTC")
+}

--- a/legacy/user.go
+++ b/legacy/user.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+import (
+	"fmt"
+)
+
+// UserService handles communication with the report related methods of the H1 API.
+type UserService service
+
+// UserTeamContext appears on some user objects
+type UserTeamContext struct {
+	NumberOfReportsToSameTeam            *uint64 `json:"number_of_reports_to_same_team"`
+	NumberOfResolvedReportsToSameTeam    *uint64 `json:"number_of_resolved_reports_to_same_team"`
+	NumberOfBountiesReceivedFromSameTeam *uint64 `json:"number_of_bounties_received_from_same_team"`
+	SumBountyAmountReceivedFromSameTeam  *string `json:"sum_bounty_amount_received_from_same_team"`
+}
+
+// User represents a H1 user
+type User struct {
+	ID                 *uint64            `json:"id"`
+	Username           *string            `json:"username"`
+	Name               *string            `json:"name"`
+	Biography          *string            `json:"bio"`
+	URL                *string            `json:"url"`
+	ProfilePictureURLs ProfilePictureURLs `json:"profile_picture_urls"`
+	Disabled           *bool              `json:"disabled"`
+	ReportCount        *uint64            `json:"report_count"`
+	TargetCount        *uint64            `json:"target_count"`
+	Reputation         *uint64            `json:"reputation"`
+	Rank               *uint64            `json:"rank"`
+	Signal             *float64           `json:"signal"`
+	Impact             *float64           `json:"impact"`
+	SignalPercentile   *uint              `json:"signal_percentile"`
+	ImpactPercentile   *uint              `json:"impact_percentile"`
+	TeamContext        *UserTeamContext   `json:"team_context"`
+}
+
+// Get looks up a user by username
+func (s *UserService) Get(username string) (*User, *Response, error) {
+	req, err := s.client.NewRequest("GET", username, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	user := new(User)
+	resp, err := s.client.Do(req, user)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return user, resp, err
+}
+
+// ListPublicTeams returns the public teams associated with a username
+func (s *UserService) ListPublicTeams(username string) ([]Team, *Response, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/public_teams", username), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	wrapper := &struct {
+		Items []Team `json:"items"`
+	}{
+		Items: []Team{},
+	}
+	resp, err := s.client.Do(req, wrapper)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return wrapper.Items, resp, err
+}
+
+// ListThanks returns the thanks associated with a usernamme
+func (s *UserService) ListThanks(username string) ([]Team, *Response, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/thanks", username), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	wrapper := &struct {
+		Items []Team `json:"items"`
+	}{
+		Items: []Team{},
+	}
+	resp, err := s.client.Do(req, wrapper)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return wrapper.Items, resp, err
+}
+
+// ListBadges returns the thanks associated with a usernamme
+func (s *UserService) ListBadges(username string) ([]Badge, *Response, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("%s/badges", username), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+
+	wrapper := &struct {
+		Items []Badge `json:"items"`
+	}{
+		Items: []Badge{},
+	}
+	resp, err := s.client.Do(req, wrapper)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return wrapper.Items, resp, err
+}

--- a/legacy/user.go
+++ b/legacy/user.go
@@ -21,7 +21,7 @@
 package legacy
 
 import (
-	"fmt"
+//	"fmt"
 )
 
 // UserService handles communication with the report related methods of the H1 API.
@@ -55,7 +55,7 @@ type User struct {
 	TeamContext        *UserTeamContext   `json:"team_context"`
 }
 
-// Get looks up a user by username
+/*// Get looks up a user by username
 func (s *UserService) Get(username string) (*User, *Response, error) {
 	req, err := s.client.NewRequest("GET", username, nil)
 	if err != nil {
@@ -137,4 +137,4 @@ func (s *UserService) ListBadges(username string) ([]Badge, *Response, error) {
 	}
 
 	return wrapper.Items, resp, err
-}
+}*/

--- a/legacy/vulnerability-type.go
+++ b/legacy/vulnerability-type.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package legacy
+
+// VulnerabilityType represents a report's vulnerability type
+type VulnerabilityType struct {
+	ID   *uint64 `json:"id"`
+	Name *string `json:"name"`
+}


### PR DESCRIPTION
Used to interface directly with H1 via the standard web routes until the API supports all functionality available in the web UI.
