### PR TITLE
Added 'page[size]' support to ListOptions

### DIFF
--- a/h1/h1.go
+++ b/h1/h1.go
@@ -60,8 +60,11 @@ type service struct {
 
 // ListOptions specifies the optional parameters to various List methods that support pagination.
 type ListOptions struct {
-	// For paginated result which page to retrieve.
+	// For paginated results which page to retrieve.
 	Page uint64 `url:"page[number],omitempty"`
+
+	// For paginated results the size of pages to retrieve
+	PageSize uint64 `url:"page[size],omitempty"`
 
 	// For lists the index to sort by
 	Sort string `url:"sort,omitempty"`


### PR DESCRIPTION
HackerOne [recently](https://api.hackerone.com/docs/v1#changelog) added support for page size queries:

> November 23rd, 2016: added ability to set a page size when querying reports.

This pull request adds support for this new functionality via a new optional `PageSize` field in the `ListOptions` struct.