### PR TITLE
Added reputation, signal, impact to User struct

### DIFF
--- a/h1/activity_test.go
+++ b/h1/activity_test.go
@@ -72,7 +72,10 @@ func Test_ActivityActor_User(t *testing.T) {
 			Size110x110: String("/assets/avatars/default.png"),
 			Size260x260: String("/assets/avatars/default.png"),
 		},
-		CreatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
+		Reputation: Uint64(7),
+		Signal:     Float64(7.0),
+		Impact:     Float64(30.0),
+		CreatedAt:  NewTimestamp("2016-02-02T04:05:06.000Z"),
 	}
 	assert.Equal(t, expectedActor, actualActor)
 }

--- a/h1/resource.go
+++ b/h1/resource.go
@@ -77,3 +77,9 @@ func String(v string) *string { return &v }
 
 // Int allocates a new bool value to store v at and returns a pointer to it.
 func Int(v int) *int { return &v }
+
+// Uint64 allocates a new uint64 value to store v at and returns a pointer to it.
+func Uint64(v uint64) *uint64 { return &v }
+
+// Float64 allocates a new float64 value to store v at and returns a pointer to it.
+func Float64(v float64) *float64 { return &v }

--- a/h1/tests/resources/user.json
+++ b/h1/tests/resources/user.json
@@ -11,6 +11,9 @@
       "82x82": "/assets/avatars/default.png",
       "110x110": "/assets/avatars/default.png",
       "260x260": "/assets/avatars/default.png"
-    }
+    },
+    "reputation": 7,
+    "signal": 7.0,
+    "impact": 30.0
   }
 }

--- a/h1/user.go
+++ b/h1/user.go
@@ -42,6 +42,9 @@ type User struct {
 	Username       *string            `json:"username"`
 	Name           *string            `json:"name"`
 	ProfilePicture UserProfilePicture `json:"profile_picture"`
+	Reputation     *uint64            `json:"reputation"`
+	Signal         *float64           `json:"signal"`
+	Impact         *float64           `json:"impact"`
 	CreatedAt      *Timestamp         `json:"created_at"`
 }
 

--- a/h1/user.go
+++ b/h1/user.go
@@ -42,9 +42,9 @@ type User struct {
 	Username       *string            `json:"username"`
 	Name           *string            `json:"name"`
 	ProfilePicture UserProfilePicture `json:"profile_picture"`
-	Reputation     *uint64            `json:"reputation"`
-	Signal         *float64           `json:"signal"`
-	Impact         *float64           `json:"impact"`
+	Reputation     *uint64            `json:"reputation,omitempty"`
+	Signal         *float64           `json:"signal,omitempty"`
+	Impact         *float64           `json:"impact,omitempty"`
 	CreatedAt      *Timestamp         `json:"created_at"`
 }
 

--- a/h1/user_test.go
+++ b/h1/user_test.go
@@ -41,7 +41,10 @@ func Test_User(t *testing.T) {
 			Size110x110: String("/assets/avatars/default.png"),
 			Size260x260: String("/assets/avatars/default.png"),
 		},
-		CreatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
+		Reputation: Uint64(7),
+		Signal:     Float64(7.0),
+		Impact:     Float64(30.0),
+		CreatedAt:  NewTimestamp("2016-02-02T04:05:06.000Z"),
 	}
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
HackerOne [previously](https://api.hackerone.com/docs/v1#changelog) added the reputation, signal and impact values to certain User object responses:

> August 24th, 2016: added reputation, signal, and impact metrics of a report's reporter.

This pull request adds support for these new fields via optional fields in the `User` struct.