### PR TITLE
Add support for the Severity resource, relationships and activity

### DIFF
--- a/h1/activity_test.go
+++ b/h1/activity_test.go
@@ -786,6 +786,22 @@ func Test_ActivityReportVulnerabilityTypesUpdated(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func Test_ActivityReportSeverityUpdated(t *testing.T) {
+	var actual Activity
+	loadResource(t, &actual, "tests/resources/activity-report-severity-updated.json")
+	expected := Activity{
+		ID:        String("1337"),
+		Type:      String(ActivityReportSeverityUpdatedType),
+		Message:   String("Report Severity Updated!"),
+		Internal:  Bool(false),
+		CreatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
+		UpdatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
+	}
+	actual.rawData = nil
+	actual.RawActor = nil
+	assert.Equal(t, expected, actual)
+}
+
 func Test_ActivitySwagAwarded(t *testing.T) {
 	var actual Activity
 	loadResource(t, &actual, "tests/resources/activity-swag-awarded.json")

--- a/h1/report.go
+++ b/h1/report.go
@@ -64,6 +64,7 @@ type Report struct {
 	Attachments              []Attachment        `json:"attachments,omitempty"`
 	Swag                     []Swag              `json:"swag,omitempty"`
 	VulnerabilityTypes       []VulnerabilityType `json:"vulnerability_types"`
+	Severity                 *Severity           `json:"severity,omitempty"`
 	Reporter                 *User               `json:"reporter,omitempty"`
 	Activities               []Activity          `json:"activities,omitempty"`
 	Bounties                 []Bounty            `json:"bounties,omitempty"`
@@ -91,6 +92,9 @@ type reportUnmarshalHelper struct {
 		VulnerabilityTypes struct {
 			Data []VulnerabilityType `json:"data"`
 		} `json:"vulnerability_types"`
+		Severity struct {
+			Data *Severity `json:"data"`
+		} `json:"severity"`
 		Reporter struct {
 			Data *User `json:"data"`
 		} `json:"reporter"`
@@ -119,6 +123,7 @@ func (r *Report) UnmarshalJSON(b []byte) error {
 	r.Attachments = helper.Relationships.Attachments.Data
 	r.Swag = helper.Relationships.Swag.Data
 	r.VulnerabilityTypes = helper.Relationships.VulnerabilityTypes.Data
+	r.Severity = helper.Relationships.Severity.Data
 	r.Reporter = helper.Relationships.Reporter.Data
 	r.Activities = helper.Relationships.Activities.Data
 	for idx := range r.Activities {

--- a/h1/resource.go
+++ b/h1/resource.go
@@ -54,6 +54,7 @@ const (
 	ActivityReportBecamePublicType              string = "activity-report-became-public"
 	ActivityReportTitleUpdatedType              string = "activity-report-title-updated"
 	ActivityReportVulnerabilityTypesUpdatedType string = "activity-report-vulnerability-types-updated"
+	ActivityReportSeverityUpdatedType           string = "activity-report-severity-updated"
 	ActivitySwagAwardedType                     string = "activity-swag-awarded"
 	ActivityUserAssignedToBugType               string = "activity-user-assigned-to-bug"
 	ActivityUserBannedFromProgramType           string = "activity-user-banned-from-program"
@@ -65,6 +66,7 @@ const (
 	ReportSummaryType                           string = "report-summary"
 	ReportType                                  string = "report"
 	SwagType                                    string = "swag"
+	SeverityType                                string = "severity"
 	UserType                                    string = "user"
 	VulnerabilityTypeType                       string = "vulnerability-type"
 )
@@ -77,3 +79,6 @@ func String(v string) *string { return &v }
 
 // Int allocates a new bool value to store v at and returns a pointer to it.
 func Int(v int) *int { return &v }
+
+// Float64 allocates a new float64 value to store v at and returns a pointer to it.
+func Float64(v float64) *float64 { return &v }

--- a/h1/severity.go
+++ b/h1/severity.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package h1
+
+import (
+	"encoding/json"
+)
+
+// SeverityRating represent possible severity ratings
+//
+// HackerOne API docs: https://api.hackerone.com/docs/v1#severity
+const (
+	SeverityRatingNone              string = "none"
+	SeverityRatingLow               string = "low"
+	SeverityRatingMedium            string = "medium"
+	SeverityRatingHigh              string = "high"
+	SeverityAuthorTypeUser          string = "User"
+	SeverityAuthorTypeTeam          string = "Team"
+	SeverityAttackVectorNetwork     string = "network"
+	SeverityAttackVectorAdjacent    string = "adjacent"
+	SeverityAttackVectorLocal       string = "local"
+	SeverityAttackVectorPhysical    string = "physical"
+	SeverityAttackComplexityLow     string = "low"
+	SeverityAttackComplexityHigh    string = "high"
+	SeverityPrivilegesRequiredLow   string = "low"
+	SeverityPrivilegesRequiredHigh  string = "high"
+	SeverityUserInteractionNone     string = "none"
+	SeverityUserInteractionRequired string = "required"
+	SeverityScopeUnchanged          string = "unchanged"
+	SeverityScopeChanged            string = "changed"
+	SeverityConfidentialityLow      string = "low"
+	SeverityConfidentialityHigh     string = "high"
+	SeverityIntegrityLow            string = "low"
+	SeverityIntegrityHigh           string = "high"
+	SeverityAvailabilityLow         string = "low"
+	SeverityAvailabilityHigh        string = "high"
+)
+
+// Severity represents a severity object
+//
+// HackerOne API docs: https://api.hackerone.com/docs/v1#severity
+type Severity struct {
+	ID                 *string    `json:"id"`
+	Type               *string    `json:"type"`
+	Rating             *string    `json:"rating"`
+	AuthorType         *string    `json:"author_type"`
+	UserID             *int       `json:"user_id"` // TODO: This is inconsistant with the rest of the API, maybe auto-cast to string
+	Score              *float64   `json:"score,omitempty"`
+	AttackVector       *string    `json:"attack_vector,omitempty"`
+	AttackComplexity   *string    `json:"attack_complexity,omitempty"`
+	PrivilegesRequired *string    `json:"privileges_required,omitempty"`
+	UserInteraction    *string    `json:"user_interaction,omitempty"`
+	Scope              *string    `json:"scope,omitempty"`
+	Confidentiality    *string    `json:"confidentiality,omitempty"`
+	Integrity          *string    `json:"integrity,omitempty"`
+	Availability       *string    `json:"availability,omitempty"`
+	CreatedAt          *Timestamp `json:"created_at"`
+}
+
+// Helper types for JSONUnmarshal
+type severity Severity // Used to avoid recursion of JSONUnmarshal
+type severityUnmarshalHelper struct {
+	severity
+	Attributes *severity `json:"attributes"`
+}
+
+// UnmarshalJSON allows JSONAPI attributes and relationships to unmarshal cleanly.
+func (s *Severity) UnmarshalJSON(b []byte) error {
+	var helper severityUnmarshalHelper
+	helper.Attributes = &helper.severity
+	if err := json.Unmarshal(b, &helper); err != nil {
+		return err
+	}
+	*s = Severity(helper.severity)
+	return nil
+}

--- a/h1/severity_test.go
+++ b/h1/severity_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package h1
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+func Test_Severity(t *testing.T) {
+	var actual Severity
+	loadResource(t, &actual, "tests/resources/severity.json")
+	expected := Severity{
+		ID:                 String("57"),
+		Type:               String(SeverityType),
+		Rating:             String(SeverityRatingHigh),
+		AuthorType:         String(SeverityAuthorTypeUser),
+		UserID:             Int(1337),
+		CreatedAt:          NewTimestamp("2016-02-02T04:05:06.000Z"),
+		Score:              Float64(8.7),
+		AttackComplexity:   String(SeverityAttackComplexityLow),
+		AttackVector:       String(SeverityAttackVectorAdjacent),
+		Availability:       String(SeverityAvailabilityHigh),
+		Confidentiality:    String(SeverityConfidentialityLow),
+		Integrity:          String(SeverityIntegrityHigh),
+		PrivilegesRequired: String(SeverityPrivilegesRequiredLow),
+		UserInteraction:    String(SeverityUserInteractionRequired),
+		Scope:              String(SeverityScopeChanged),
+	}
+	assert.Equal(t, expected, actual)
+}

--- a/h1/tests/resources/activity-report-severity-updated.json
+++ b/h1/tests/resources/activity-report-severity-updated.json
@@ -1,0 +1,30 @@
+{
+  "id": "1337",
+  "type": "activity-report-severity-updated",
+  "attributes": {
+    "message": "Report Severity Updated!",
+    "created_at": "2016-02-02T04:05:06.000Z",
+    "updated_at": "2016-02-02T04:05:06.000Z",
+    "internal": false
+  },
+  "relationships": {
+    "actor": {
+      "data": {
+        "id": "1337",
+        "type": "user",
+        "attributes": {
+          "username": "api-example",
+          "name": "API Example",
+          "disabled": false,
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "profile_picture": {
+            "62x62": "/assets/avatars/default.png",
+            "82x82": "/assets/avatars/default.png",
+            "110x110": "/assets/avatars/default.png",
+            "260x260": "/assets/avatars/default.png"
+          }
+        }
+      }
+    }
+  }
+}

--- a/h1/tests/resources/severity.json
+++ b/h1/tests/resources/severity.json
@@ -1,0 +1,19 @@
+{
+  "id": "57",
+  "type": "severity",
+  "attributes": {
+    "rating": "high",
+    "author_type": "User",
+    "user_id": 1337,
+    "created_at": "2016-02-02T04:05:06.000Z",
+    "score": 8.7,
+    "attack_complexity": "low",
+    "attack_vector": "adjacent",
+    "availability": "high",
+    "confidentiality": "low",
+    "integrity": "high",
+    "privileges_required": "low",
+    "user_interaction": "required",
+    "scope": "changed"
+  }
+}


### PR DESCRIPTION
HackerOne [recently](https://api.hackerone.com/docs/v1#changelog) added support for severity on reports and subsequently updated their API:

> October 5th, 2016: added severity relationship to report object.

This pull request adds support for this new functionality via a new `Severity` resource, `Severity` relationship on `Report` objects and a new `ActivityReportSeverityUpdatedType` in activities.
