### PR TITLE
Fix typo in Swag object

### DIFF
--- a/h1/activity_test.go
+++ b/h1/activity_test.go
@@ -804,7 +804,7 @@ func Test_ActivitySwagAwarded(t *testing.T) {
 			ID:        String("1337"),
 			Type:      String(SwagType),
 			Sent:      Bool(false),
-			UpdatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
+			CreatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
 			Address: &Address{
 				ID:          String("1337"),
 				Type:        String(AddressType),

--- a/h1/swag.go
+++ b/h1/swag.go
@@ -31,7 +31,7 @@ type Swag struct {
 	ID        *string    `json:"id"`
 	Type      *string    `json:"type"`
 	Sent      *bool      `json:"sent"`
-	UpdatedAt *Timestamp `json:"created_at"`
+	CreatedAt *Timestamp `json:"created_at"`
 	Address   *Address   `json:"address,omitempty"`
 }
 

--- a/h1/swag_test.go
+++ b/h1/swag_test.go
@@ -33,7 +33,7 @@ func Test_Swag(t *testing.T) {
 		ID:        String("1337"),
 		Type:      String(SwagType),
 		Sent:      Bool(false),
-		UpdatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
+		CreatedAt: NewTimestamp("2016-02-02T04:05:06.000Z"),
 		Address: &Address{
 			ID:          String("1337"),
 			Type:        String(AddressType),


### PR DESCRIPTION
The `CreatedAt` field was incorrectly named `UpdatedAt` but still parsed the correct values. Updated field name.