### PR TITLE
Add Report state change, assignee update, and comment functionality

### DIFF
--- a/h1/h1.go
+++ b/h1/h1.go
@@ -24,8 +24,10 @@ package h1
 import (
 	"github.com/google/go-querystring/query"
 
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -104,6 +106,11 @@ func NewClient(httpClient *http.Client) *Client {
 	return c
 }
 
+// dataRequest is used to cast requests to H1
+type dataRequest struct {
+	Data interface{} `json:"data,omitempty"`
+}
+
 // NewRequest creates an API request. A relative URL can be provided in urlStr
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
 	rel, err := url.Parse(urlStr)
@@ -111,9 +118,25 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
-	req, err := http.NewRequest(method, c.BaseURL.ResolveReference(rel).String(), nil)
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		dat := dataRequest{
+			Data: body,
+		}
+		err := json.NewEncoder(buf).Encode(&dat)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, c.BaseURL.ResolveReference(rel).String(), buf)
 	if err != nil {
 		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Add("Content-Type", "application/json")
 	}
 
 	req.Header.Add("User-Agent", c.UserAgent)

--- a/h1/h1_test.go
+++ b/h1/h1_test.go
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -142,6 +143,14 @@ func Test_NewRequest(t *testing.T) {
 	// Check that an invalid URL fails
 	client := NewClient(nil)
 	_, err := client.NewRequest("GET", "http://[fe80::1%en0]/", nil)
+	assert.NotNil(t, err)
+
+	// Check that an invalid body fails
+	_, err = client.NewRequest("GET", "/", struct {
+		InvalidField float64 `json:"invalid_field"`
+	}{
+		math.NaN(),
+	})
 	assert.NotNil(t, err)
 
 	// Check that an invalid base URL fails

--- a/h1/report_service.go
+++ b/h1/report_service.go
@@ -108,6 +108,40 @@ func (s *ReportService) UpdateAssignee(ID string, message string, assignee inter
 	return rResp, resp, err
 }
 
+// reportUpdateAssigneeRequest is used for making report assignee updates
+type reportStateChangeRequestAttributes struct {
+	Message string `json:"message,omitempty"`
+	State   string `json:"state"`
+}
+type reportStateChangeRequest struct {
+	Type       string                             `json:"type"`
+	Attributes reportStateChangeRequestAttributes `json:"attributes"`
+}
+
+// UpdateState changes a report's state by ID
+func (s *ReportService) UpdateState(ID string, state string, message string) (*Report, *Response, error) {
+	request := &reportStateChangeRequest{
+		Type: "state-change",
+		Attributes: reportStateChangeRequestAttributes{
+			Message: message,
+			State:   state,
+		},
+	}
+
+	req, err := s.client.NewRequest("POST", fmt.Sprintf("reports/%s/state_changes", ID), request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rResp := new(Report)
+	resp, err := s.client.Do(req, rResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rResp, resp, err
+}
+
 // ReportListFilter specifies optional parameters to the ReportService.List method.
 //
 // HackerOne API docs: https://api.hackerone.com/docs/v1#reports/query

--- a/h1/report_service.go
+++ b/h1/report_service.go
@@ -44,6 +44,22 @@ func (s *ReportService) Get(ID string) (*Report, *Response, error) {
 	return rResp, resp, err
 }
 
+// CreateComment creates a Comment on a report by ID
+func (s *ReportService) CreateComment(ID string, comment *Activity) (*Activity, *Response, error) {
+	req, err := s.client.NewRequest("POST", fmt.Sprintf("reports/%s/activities", ID), comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rResp := new(Activity)
+	resp, err := s.client.Do(req, rResp)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return rResp, resp, err
+}
+
 // ReportListFilter specifies optional parameters to the ReportService.List method.
 //
 // HackerOne API docs: https://api.hackerone.com/docs/v1#reports/query

--- a/h1/report_service_test.go
+++ b/h1/report_service_test.go
@@ -120,7 +120,7 @@ func Test_ReportService_CreateComment(t *testing.T) {
 	// Verify that an invalid url fails
 	c := NewClient(nil)
 	c.BaseURL = &url.URL{}
-	_, _, err := c.Report.CreateComment("%A", nil)
+	_, _, err := c.Report.CreateComment("%A", "A fix has been deployed. Can you retest, please?", false)
 	assert.NotNil(t, err)
 
 	// Verify that an error response fails
@@ -131,7 +131,7 @@ func Test_ReportService_CreateComment(t *testing.T) {
 	u, err := url.Parse(errorServer.URL)
 	assert.Nil(t, err)
 	c.BaseURL = u
-	_, _, err = c.Report.CreateComment("123456", nil)
+	_, _, err = c.Report.CreateComment("123456", "A fix has been deployed. Can you retest, please?", false)
 	assert.NotNil(t, err)
 
 	// Verify that it gets a response correctly and it has the correct request body
@@ -151,15 +151,101 @@ func Test_ReportService_CreateComment(t *testing.T) {
 	u, err = url.Parse(commentServer.URL)
 	assert.Nil(t, err)
 	c.BaseURL = u
-	actual, _, err := c.Report.CreateComment("123456", &Activity{
-		Type:     String(ActivityCommentType),
-		Internal: Bool(false),
-		Message:  String("A fix has been deployed. Can you retest, please?"),
-	})
+	actual, _, err := c.Report.CreateComment("123456", "A fix has been deployed. Can you retest, please?", false)
 	assert.Nil(t, err)
 	actual.RawActor = nil
 	actual.rawData = nil
 	assert.Equal(t, &expectedComment, actual)
+}
+
+var expectedUpdateAssigneeRequest1 = `{"data":{"type":"nobody","attributes":{"message":"@member Please check this out!"}}}`
+var expectedUpdateAssigneeRequest2 = `{"data":{"id":"1337","type":"user","attributes":{"message":"@member Please check this out!"}}}`
+var expectedUpdateAssigneeRequest3 = `{"data":{"id":"1337","type":"group","attributes":{"message":"@member Please check this out!"}}}`
+
+func Test_ReportService_UpdateAssignee(t *testing.T) {
+	// Verify that an invalid url fails
+	c := NewClient(nil)
+	c.BaseURL = &url.URL{}
+	_, _, err := c.Report.UpdateAssignee("%A", "", nil)
+	assert.NotNil(t, err)
+
+	// Verify that an error response fails
+	errorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Oh No", 500)
+	}))
+	defer errorServer.Close()
+	u, err := url.Parse(errorServer.URL)
+	assert.Nil(t, err)
+	c.BaseURL = u
+	_, _, err = c.Report.UpdateAssignee("123456", "", nil)
+	assert.NotNil(t, err)
+
+	// Verify that it gets a response correctly and it has the correct request body
+	reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(string(body)) != strings.TrimSpace(expectedUpdateAssigneeRequest1) {
+			http.Error(w, "Non-matching request!", http.StatusBadRequest)
+			return
+		}
+		http.ServeFile(w, r, "tests/responses/report.json")
+	}))
+	defer reportServer.Close()
+	u, err = url.Parse(reportServer.URL)
+	assert.Nil(t, err)
+	c.BaseURL = u
+	actual, _, err := c.Report.UpdateAssignee("123456", "@member Please check this out!", nil)
+	assert.Nil(t, err)
+	assert.Equal(t, &expectedReport, actual)
+
+	// Verify that it gets a response correctly and it has the correct request body
+	reportServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(string(body)) != strings.TrimSpace(expectedUpdateAssigneeRequest2) {
+			http.Error(w, "Non-matching request!", http.StatusBadRequest)
+			return
+		}
+		http.ServeFile(w, r, "tests/responses/report.json")
+	}))
+	defer reportServer.Close()
+	u, err = url.Parse(reportServer.URL)
+	assert.Nil(t, err)
+	c.BaseURL = u
+	actual, _, err = c.Report.UpdateAssignee("123456", "@member Please check this out!", &User{
+		ID: String("1337"),
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, &expectedReport, actual)
+
+	// Verify that it gets a response correctly and it has the correct request body
+	reportServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(string(body)) != strings.TrimSpace(expectedUpdateAssigneeRequest3) {
+			http.Error(w, "Non-matching request!", http.StatusBadRequest)
+			return
+		}
+		http.ServeFile(w, r, "tests/responses/report.json")
+	}))
+	defer reportServer.Close()
+	u, err = url.Parse(reportServer.URL)
+	assert.Nil(t, err)
+	c.BaseURL = u
+	actual, _, err = c.Report.UpdateAssignee("123456", "@member Please check this out!", &Group{
+		ID: String("1337"),
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, &expectedReport, actual)
 }
 
 func Test_ReportService_List(t *testing.T) {

--- a/h1/tests/responses/report_create-comment.json
+++ b/h1/tests/responses/report_create-comment.json
@@ -1,0 +1,32 @@
+{
+  "data": {
+    "id": "1337",
+    "type": "activity-comment",
+    "attributes": {
+      "message": "A fix has been deployed. Can you retest, please?",
+      "created_at": "2016-02-02T04:05:06.000Z",
+      "updated_at": "2016-02-02T04:05:06.000Z",
+      "internal": false
+    },
+    "relationships": {
+      "actor": {
+        "data": {
+          "id": "1337",
+          "type": "user",
+          "attributes": {
+            "username": "api-example",
+            "name": "API Example",
+            "disabled": false,
+            "created_at": "2016-02-02T04:05:06.000Z",
+            "profile_picture": {
+              "62x62": "/assets/avatars/default.png",
+              "82x82": "/assets/avatars/default.png",
+              "110x110": "/assets/avatars/default.png",
+              "260x260": "/assets/avatars/default.png"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
HackerOne [previously](https://api.hackerone.com/docs/v1#changelog) added endpoints for creating comments, updating a report's assignee, and updating a report's state:

> September 21st, 2016: added ability to assign users and groups to a report.
> November 2nd, 2016: added ability to change the state of a report object and added ability to post internal and public comments.

This pull request adds support for these endpoints via additional methods on the `ReportService` struct. Since there are the first state-changing endpoints with POST bodies changes were made to `h1.go` to add support for request bodies. Additionally this was the first time a struct (`Activity`) had to be JSON marshalled so some changes have been made there. I'm open to suggestions about the best method to do this since I'm not thrilled with the current implementation but it does work...